### PR TITLE
Smaller values in potential map. 

### DIFF
--- a/Assets/Scripts/Managers/PotentialMap.cs
+++ b/Assets/Scripts/Managers/PotentialMap.cs
@@ -72,6 +72,7 @@ namespace IGDSS20.Assets.Scripts.Navigation
                     if (totalWeight < previousWeight)
                     {
                         UpdateWeight(tile, totalWeight);
+                        AddNeighboringPotentialFields(tile, totalWeight);
                     }
                 }
             }


### PR DESCRIPTION
Hey ;-) 
Following our latest conversation, I added on little line of code to the PotentialMapManager. If a higher potential (lower value) is found for an already checked tile, the neighboring tiles will now also be checked again because they could be effected too. The resulting potentials look way more realistic as they are way smaller. :-)